### PR TITLE
Index reports from unitedstates/reports

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -1,6 +1,11 @@
-# inspectors-general data directory, defaults to ./data
+# unitedstates/inspectors-general data directory, defaults to ./data
 inspectors:
   data: data
+
+# unitedstates/reports data directory, uncomment and change to point to a
+# clone of https://github.com/unitedstates/reports.git
+#reports:
+#  data: ../reports
 
 # elasticsearch server address
 elasticsearch:

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -1,17 +1,14 @@
 #!/usr/bin/env node
 
+"use strict";
+
 /**
- * Load data from unitedstates/inspectors-general into Elasticsearch.
+ * Load data from unitedstates/inspectors-general and unitedstates/reports
+ * into Elasticsearch.
  *
- * Iterates over the IG data folder, one level at a time.
+ * Iterates over the IG data folders, one level at a time.
  * Defaults to all available agencies, all available years,
  * and all available reports in that year.
- *
- * Supported options:
- *   since: limit to all since a given year. defaults to current year.
- *   inspectors: limit to list of inspector slugs (comma-separated)
- *   report_id: limit to individual report ID (combine with --since if needed)
- *   limit: cut off after N reports, useful for debugging
  */
 
 var fs = require('fs'),
@@ -28,20 +25,64 @@ var config = require("../config/config"),
       }
     });
 
-function run(options) {
+// load a report from disk, put it into elasticsearch
+function loadReport(details, done) {
+  var base_path = details.base_path,
+      inspector = details.inspector,
+      year = details.year,
+      report_id = details.report_id;
+  console.log("[" + inspector + "][" + year + "][" + report_id + "]");
+
+  console.log("\tLoading JSON from disk...");
+  var datafile = path.join(base_path, inspector, year.toString(), report_id, "report.json");
+  if (!fs.existsSync(datafile)) {
+    console.error("ERROR: JSON missing, report is probably a bad URL.");
+    return done();
+  }
+  var json = fs.readFileSync(datafile);
+  if (!json || json.length <= 0) return done();
+  var data = JSON.parse(json);
+
+  console.log("\tLoading text from disk...");
+  var textfile = path.join(base_path, inspector, year.toString(), report_id, "report.txt");
+  if (fs.existsSync(textfile))
+    data.text = fs.readFileSync(textfile).toString();
+
+  // and this is for IG reports
+  data.source = "igs";
+
+  // Actually load into Elasticsearch
+  console.log("\tIndexing into Elasticsearch...");
+  es.index({
+    index: config.elasticsearch.index,
+    type: 'reports',
+    id: inspector + '-' + report_id,
+    body: data
+  }, function(err) {
+    if (err) {
+      console.log("\tEr what!!");
+      console.log("\t" + err);
+      process.exit(1);
+    }
+
+    done();
+  });
+}
+
+function crawl(options, base_path) {
   var limit = options.limit ? parseInt(options.limit) : null;
   var this_year = new Date().getYear() + 1900;
   var since = options.since ? parseInt(options.since) : this_year;
   var only_id = options.report_id;
   var inspectors = options.inspectors ? options.inspectors.split(",") : null;
 
-  console.log("Loading all reports since " + since + ".");
+  console.log("Loading all reports since " + since + " from " + base_path + ".");
   if (inspectors) console.log("Limiting to: " + inspectors);
 
   var fetch = [];
   var count = 0;
   // iterate over each agency
-  glob.sync(path.join(config.inspectors.data, "*")).forEach(function(inspector_dir) {
+  glob.sync(path.join(base_path, "*")).forEach(function(inspector_dir) {
     var inspector = path.basename(inspector_dir);
 
     // iterate over each year
@@ -61,6 +102,7 @@ function run(options) {
         if (should_skip) return;
 
         fetch.push({
+          base_path: base_path,
           inspector: inspector,
           year: year,
           report_id: report_id
@@ -70,48 +112,13 @@ function run(options) {
       });
     });
   });
+  return fetch;
+}
 
-  // load a report from disk, put it into elasticsearch
-  function loadReport(details, done) {
-    var inspector = details.inspector,
-        year = details.year,
-        report_id = details.report_id;
-    console.log("[" + inspector + "][" + year + "][" + report_id + "]");
-
-    console.log("\tLoading JSON from disk...");
-    var datafile = path.join(config.inspectors.data, inspector, year.toString(), report_id, "report.json");
-    if (!fs.existsSync(datafile)) {
-      console.error("ERROR: JSON missing, report is probably a bad URL.");
-      return done();
-    }
-    var json = fs.readFileSync(datafile);
-    if (!json || json.length <= 0) return done();
-    var data = JSON.parse(json);
-
-    console.log("\tLoading text from disk...");
-    var textfile = path.join(config.inspectors.data, inspector, year.toString(), report_id, "report.txt");
-    if (fs.existsSync(textfile))
-      data.text = fs.readFileSync(textfile).toString();
-
-    // and this is for IG reports
-    data.source = "igs";
-
-    // Actually load into Elasticsearch
-    console.log("\tIndexing into Elasticsearch...");
-    es.index({
-      index: config.elasticsearch.index,
-      type: 'reports',
-      id: inspector + '-' + report_id,
-      body: data
-    }, function(err) {
-      if (err) {
-        console.log("\tEr what!!");
-        console.log("\t" + err);
-        process.exit(1);
-      }
-
-      done();
-    });
+function ingest(fetch) {
+  if (fetch.length == 0) {
+    // Don't need to refresh index if there are no reports, exit early
+    return;
   }
 
   async.eachSeries(fetch, loadReport, function(err) {
@@ -125,6 +132,38 @@ function run(options) {
       process.exit(0);
     });
   });
+}
+
+function run(options) {
+  var unknown_option = false;
+  for (var option in options) {
+    if (option != "since" &&
+        option != "inspectors" &&
+        option != "report_id" &&
+        option != "limit" &&
+        option != "_") {
+      unknown_option = option;
+    }
+  }
+  if (unknown_option) {
+    console.error("Unrecognized command line argument " + unknown_option);
+    console.error("Supported options:");
+    console.error("  since: limit to all since a given year, defaults to current year");
+    console.error("  inspectors: limit to list of inspector slugs (comma-separated)");
+    console.error("  report_id: limit to individual report ID (combine with --since if needed)");
+    console.error("  limit: cut off after N reports, useful for debugging");
+    process.exit(1);
+  }
+
+  var reports_dir = config.reports && config.reports.data;
+  var scraper_data_list = crawl(options, config.inspectors.data);
+  ingest(scraper_data_list);
+
+  if (reports_dir) {
+    var reports_ig_dir = path.join(reports_dir, "inspectors-general");
+    var reports_list = crawl(options, reports_ig_dir);
+    ingest(reports_list);
+  }
 }
 
 run(require('minimist')(process.argv.slice(2)));

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -116,7 +116,7 @@ function crawl(options, base_path) {
 }
 
 function ingest(fetch) {
-  if (fetch.length == 0) {
+  if (fetch.length === 0) {
     // Don't need to refresh index if there are no reports, exit early
     return;
   }

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -141,7 +141,8 @@ function run(options) {
         option != "inspectors" &&
         option != "report_id" &&
         option != "limit" &&
-        option != "_") {
+        option != "_" &&
+        option != "config") {
       unknown_option = option;
     }
   }
@@ -152,6 +153,7 @@ function run(options) {
     console.error("  inspectors: limit to list of inspector slugs (comma-separated)");
     console.error("  report_id: limit to individual report ID (combine with --since if needed)");
     console.error("  limit: cut off after N reports, useful for debugging");
+    console.error("  config: specify a different configuration file");
     process.exit(1);
   }
 

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -157,10 +157,10 @@ function run(options) {
     process.exit(1);
   }
 
-  var reports_dir = config.reports && config.reports.data;
   var scraper_data_list = crawl(options, config.inspectors.data);
   ingest(scraper_data_list);
 
+  var reports_dir = config.reports && config.reports.data;
   if (reports_dir) {
     var reports_ig_dir = path.join(reports_dir, "inspectors-general");
     var reports_list = crawl(options, reports_ig_dir);


### PR DESCRIPTION
tasks/inspectors.js is extended to also index reports that come from
other sources. (not scrapers) The working directory for the reports
repository can be set in the config file. A cron job to update the
reports directory once a week is left as an exercise for the reader.

Fixes unitedstates/inspectors-general#204.