### PR TITLE
Update deps

### DIFF
--- a/app/boot.js
+++ b/app/boot.js
@@ -5,6 +5,7 @@ var config = require("../config/config"),
 
 module.exports = {
   es: new elasticsearch.Client({
+    apiVersion: "1.7",
     host: {
       host: config.elasticsearch.host,
       port: config.elasticsearch.port

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -401,11 +401,6 @@
       "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
     },
-    "http-signature": {
-      "version": "0.11.0",
-      "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
-    },
     "inflight": {
       "version": "1.0.4",
       "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
@@ -656,14 +651,102 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
     },
     "request": {
-      "version": "2.65.0",
-      "from": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.65.0.tgz",
+      "version": "2.67.0",
+      "from": "request@2.67.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "dependencies": {
+        "node-uuid": {
+          "version": "1.4.7",
+          "from": "node-uuid@>=1.4.7 <1.5.0",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+        },
         "qs": {
           "version": "5.2.0",
-          "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+          "from": "qs@>=5.2.0 <5.3.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.0",
+          "from": "http-signature@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+          "dependencies": {
+            "jsprim": {
+              "version": "1.2.2",
+              "from": "jsprim@>=1.2.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+              "dependencies": {
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "from": "extsprintf@1.0.2",
+                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                },
+                "json-schema": {
+                  "version": "0.2.2",
+                  "from": "json-schema@0.2.2",
+                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "from": "verror@1.3.6",
+                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                }
+              }
+            },
+            "sshpk": {
+              "version": "1.7.3",
+              "from": "sshpk@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
+              "dependencies": {
+                "asn1": {
+                  "version": "0.2.3",
+                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "dashdash": {
+                  "version": "1.12.1",
+                  "from": "dashdash@>=1.10.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    }
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.0",
+                  "from": "jsbn@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                },
+                "tweetnacl": {
+                  "version": "0.13.3",
+                  "from": "tweetnacl@>=0.13.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23,9 +23,9 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
     "asn1": {
-      "version": "0.1.11",
-      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+      "version": "0.2.3",
+      "from": "asn1@0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "0.1.5",
@@ -54,7 +54,7 @@
     },
     "body-parser": {
       "version": "1.14.2",
-      "from": "body-parser@1.14.2",
+      "from": "body-parser@>=1.14.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
       "dependencies": {
         "bytes": {
@@ -76,25 +76,6 @@
           "version": "2.1.5",
           "from": "raw-body@>=2.1.5 <2.2.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz"
-        },
-        "type-is": {
-          "version": "1.6.10",
-          "from": "type-is@>=1.6.10 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
-          "dependencies": {
-            "mime-types": {
-              "version": "2.1.9",
-              "from": "mime-types@>=2.1.8 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.21.0",
-                  "from": "mime-db@>=1.21.0 <1.22.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -217,25 +198,20 @@
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "from": "dom-serializer@0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-        },
         "entities": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "from": "entities@>=1.1.1 <1.2.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+      "version": "1.1.3",
+      "from": "domelementtype@1.1.3",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
@@ -572,14 +548,14 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
-      "version": "1.19.0",
-      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+      "version": "1.21.0",
+      "from": "mime-db@1.21.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
     },
     "mime-types": {
-      "version": "2.1.7",
-      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
+      "version": "2.1.9",
+      "from": "mime-types@2.1.9",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz"
     },
     "minimatch": {
       "version": "3.0.0",
@@ -602,9 +578,9 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
     },
     "node-uuid": {
-      "version": "1.4.3",
-      "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+      "version": "1.4.7",
+      "from": "node-uuid@1.4.7",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "numeral": {
       "version": "1.5.3",
@@ -673,14 +649,9 @@
     },
     "request": {
       "version": "2.67.0",
-      "from": "request@2.67.0",
+      "from": "request@>=2.67.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
       "dependencies": {
-        "node-uuid": {
-          "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-        },
         "qs": {
           "version": "5.2.0",
           "from": "qs@>=5.2.0 <5.3.0",
@@ -718,11 +689,6 @@
               "from": "sshpk@>=1.7.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.3.tgz",
               "dependencies": {
-                "asn1": {
-                  "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                },
                 "assert-plus": {
                   "version": "0.2.0",
                   "from": "assert-plus@>=0.2.0 <0.3.0",
@@ -844,9 +810,9 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
     },
     "type-is": {
-      "version": "1.6.9",
-      "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz"
+      "version": "1.6.10",
+      "from": "type-is@1.6.10",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz"
     },
     "unpipe": {
       "version": "1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -58,9 +58,50 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
     "body-parser": {
-      "version": "1.14.1",
-      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.1.tgz",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.1.tgz"
+      "version": "1.14.2",
+      "from": "body-parser@1.14.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+      "dependencies": {
+        "bytes": {
+          "version": "2.2.0",
+          "from": "bytes@2.2.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+        },
+        "qs": {
+          "version": "5.2.0",
+          "from": "qs@5.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+        },
+        "raw-body": {
+          "version": "2.1.5",
+          "from": "raw-body@>=2.1.5 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz"
+        },
+        "type-is": {
+          "version": "1.6.10",
+          "from": "type-is@>=1.6.10 <1.7.0",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.1.9",
+              "from": "mime-types@>=2.1.8 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.9.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.21.0",
+                  "from": "mime-db@>=1.21.0 <1.22.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.21.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "boom": {
       "version": "2.10.1",
@@ -71,11 +112,6 @@
       "version": "1.1.1",
       "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
-    },
-    "bytes": {
-      "version": "2.1.0",
-      "from": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
     },
     "caseless": {
       "version": "0.11.0",
@@ -370,11 +406,6 @@
       "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.11.0.tgz"
     },
-    "iconv-lite": {
-      "version": "0.4.12",
-      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.12.tgz",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.12.tgz"
-    },
     "inflight": {
       "version": "1.0.4",
       "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
@@ -609,20 +640,10 @@
       "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz"
     },
-    "qs": {
-      "version": "5.1.0",
-      "from": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
-    },
     "range-parser": {
       "version": "1.0.3",
       "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
-    },
-    "raw-body": {
-      "version": "2.1.4",
-      "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.4.tgz",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.4.tgz"
     },
     "readable-stream": {
       "version": "2.0.4",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -442,26 +442,31 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "js-yaml": {
-      "version": "3.4.3",
-      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
+      "version": "3.5.2",
+      "from": "js-yaml@3.5.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.2.tgz",
       "dependencies": {
         "argparse": {
-          "version": "1.0.3",
-          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+          "version": "1.0.4",
+          "from": "argparse@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.4.tgz",
           "dependencies": {
+            "lodash": {
+              "version": "4.0.0",
+              "from": "lodash@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.0.0.tgz"
+            },
             "sprintf-js": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+              "from": "sprintf-js@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
             }
           }
         },
         "esprima": {
-          "version": "2.7.0",
-          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
+          "version": "2.7.1",
+          "from": "esprima@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33,9 +33,9 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
     },
     "async": {
-      "version": "1.5.0",
-      "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+      "version": "1.5.2",
+      "from": "async@1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,11 +52,6 @@
       "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
     },
-    "bluebird": {
-      "version": "2.10.2",
-      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-    },
     "body-parser": {
       "version": "1.14.2",
       "from": "body-parser@1.14.2",
@@ -263,9 +258,16 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.3.4.tgz"
     },
     "elasticsearch": {
-      "version": "8.2.0",
-      "from": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-8.2.0.tgz",
-      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-8.2.0.tgz"
+      "version": "10.1.2",
+      "from": "elasticsearch@10.1.2",
+      "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-10.1.2.tgz",
+      "dependencies": {
+        "promise-js": {
+          "version": "0.0.6",
+          "from": "promise-js@0.0.6",
+          "resolved": "https://registry.npmjs.org/promise-js/-/promise-js-0.0.6.tgz"
+        }
+      }
     },
     "entities": {
       "version": "1.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -374,9 +374,9 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "glob": {
-      "version": "5.0.15",
-      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
+      "version": "6.0.4",
+      "from": "glob@>=6.0.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -273,9 +273,28 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
     },
     "errorhandler": {
-      "version": "1.4.2",
-      "from": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz"
+      "version": "1.4.3",
+      "from": "errorhandler@1.4.3",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.0",
+          "from": "accepts@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.0.tgz",
+          "dependencies": {
+            "negotiator": {
+              "version": "0.6.0",
+              "from": "negotiator@0.6.0",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
+            }
+          }
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "from": "escape-html@>=1.0.3 <1.1.0",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+        }
+      }
     },
     "escape-html": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "^1.5.2",
     "body-parser": "^1.14.2",
     "ejs": "^2.3.4",
-    "elasticsearch": "8.x",
+    "elasticsearch": "^10.1.2",
     "errorhandler": "^1.4.3",
     "express": "4.x",
     "glob": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "elasticsearch": "8.x",
     "errorhandler": "^1.4.3",
     "express": "4.x",
-    "glob": "^5.0.15",
+    "glob": "^6.0.4",
     "js-yaml": "^3.5.2",
     "method-override": "^2.3.5",
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/konklone/oversight",
   "dependencies": {
     "async": "^1.5.2",
-    "body-parser": "^1.14.1",
+    "body-parser": "^1.14.2",
     "ejs": "^2.3.4",
     "elasticsearch": "8.x",
     "errorhandler": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/konklone/oversight",
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^1.5.2",
     "body-parser": "^1.14.1",
     "ejs": "^2.3.4",
     "elasticsearch": "8.x",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ejs": "^2.3.4",
     "elasticsearch": "^10.1.2",
     "errorhandler": "^1.4.3",
-    "express": "4.x",
+    "express": "^4.13.3",
     "glob": "^6.0.4",
     "js-yaml": "^3.5.2",
     "method-override": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "body-parser": "^1.14.2",
     "ejs": "^2.3.4",
     "elasticsearch": "8.x",
-    "errorhandler": "^1.4.2",
+    "errorhandler": "^1.4.3",
     "express": "4.x",
     "glob": "^5.0.15",
     "js-yaml": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "method-override": "^2.3.5",
     "minimist": "^1.2.0",
     "numeral": "^1.5.3",
-    "request": "^2.65.0"
+    "request": "^2.67.0"
   },
   "devDependencies": {
     "intercept-stdout": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "errorhandler": "^1.4.2",
     "express": "4.x",
     "glob": "^5.0.15",
-    "js-yaml": "^3.4.3",
+    "js-yaml": "^3.5.2",
     "method-override": "^2.3.5",
     "minimist": "^1.2.0",
     "numeral": "^1.5.3",

--- a/package.json
+++ b/package.json
@@ -30,24 +30,24 @@
   },
   "homepage": "https://github.com/konklone/oversight",
   "dependencies": {
-    "async": "*",
-    "body-parser": "*",
-    "ejs": "*",
+    "async": "^1.5.0",
+    "body-parser": "^1.14.1",
+    "ejs": "^2.3.4",
     "elasticsearch": "8.x",
-    "errorhandler": "*",
+    "errorhandler": "^1.4.2",
     "express": "4.x",
-    "glob": "*",
-    "js-yaml": "*",
-    "method-override": "*",
-    "minimist": "*",
-    "numeral": "*",
-    "request": "*"
+    "glob": "^5.0.15",
+    "js-yaml": "^3.4.3",
+    "method-override": "^2.3.5",
+    "minimist": "^1.2.0",
+    "numeral": "^1.5.3",
+    "request": "^2.65.0"
   },
   "devDependencies": {
-    "intercept-stdout": "*",
+    "intercept-stdout": "^0.1.2",
     "jshint": "^2.9.1",
     "mocha": "^2.3.4",
-    "tv4": "*",
+    "tv4": "^1.2.7",
     "webdriverio": "^3.4.0"
   }
 }

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -19,6 +19,7 @@ var fs = require('fs'),
 var config = require("../config/config"),
     elasticsearch = require("elasticsearch"),
     es = new elasticsearch.Client({
+      apiVersion: "1.7",
       host: {
         host: config.elasticsearch.host,
         port: config.elasticsearch.port


### PR DESCRIPTION
This updates all NPM dependencies to the latest version. The shrinkwrap file is updated as well, and I ran `npm dedupe` at the end to clean up the node_modules directory a bit.

Going forward, there's a new service at http://greenkeeper.io/ that keeps track of updated dependencies and sends PR requests whenever there's a new release that falls outside of your package's "wanted" range. @konklone interested in signing up?