### PR TITLE
Refactor config/environment.rb and rake tasks for encapsulation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,5 @@
 task :environment do
-  require 'yaml'
-  config_path = ENV['config'] || "config/config.yaml"
-  config_raw = File.read(config_path)
-  $config = YAML.load(config_raw)
-  # require './config/environment'
+  require './config/environment'
 end
 
 scss = "public/scss/main.scss"

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,10 +1,55 @@
 
+## Gets loaded once, upon app boot or during a rake task.
+
 require 'bundler/setup'
 require 'elasticsearch/persistence/model'
+require 'yaml'
+
+class Environment
+  def self.config
+    @config ||= YAML.load_file File.join(File.dirname(__FILE__), "config.yaml")
+  end
+
+  def self.init_client!
+    # Define elasticsearch client.
+    if Environment.config['elasticsearch']['host'].nil?
+      puts "The elasticsearch server's hostname is not set in the configuration file"
+      exit
+    end
+
+    if Environment.config['elasticsearch']['port'].nil?
+      puts "The elasticsearch server's port number is not set in the configuration file"
+      exit
+    end
+
+    if Environment.config['elasticsearch']['index_read'].nil?
+      puts "The elasticsearch server's index name for reading is not set in the configuration file"
+      exit
+    end
+
+    if Environment.config['elasticsearch']['index_write'].nil?
+      puts "The elasticsearch server's index name for writing is not set in the configuration file"
+      exit
+    end
+
+    log = ENV['log'] || false
+    endpoint = "http://#{Environment.config['elasticsearch']['host']}:#{Environment.config['elasticsearch']['port']}"
+    @elasticsearch_client = Elasticsearch::Client.new url: endpoint, log: log
+  end
+
+  def self.client
+    @elasticsearch_client
+  end
+end
+
+Environment.init_client!
+
+
+## Models for easy introspection.
 
 class Report
   include Elasticsearch::Persistence::Model
-  index_name $config['elasticsearch']['index_read']
+  index_name Environment.config['elasticsearch']['index_read']
   document_type "reports"
 
   attribute :title, String

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,7 +7,7 @@ require 'yaml'
 
 class Environment
   def self.config
-    @config ||= YAML.load_file File.join(File.dirname(__FILE__), (ENV["config"] || "config.yaml"))
+    @config ||= YAML.load_file(ENV["config"] || File.join(File.dirname(__FILE__), "config.yaml"))
   end
 
   def self.init_client!

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,7 +7,7 @@ require 'yaml'
 
 class Environment
   def self.config
-    @config ||= YAML.load_file File.join(File.dirname(__FILE__), "config.yaml")
+    @config ||= YAML.load_file File.join(File.dirname(__FILE__), (ENV["config"] || "config.yaml"))
   end
 
   def self.init_client!

--- a/tasks/elasticsearch.rake
+++ b/tasks/elasticsearch.rake
@@ -14,6 +14,7 @@ namespace :elasticsearch do
   task init: :environment do
     single = ENV['only'] || nil
     force = ENV['force'] || false
+    also_alias = ENV['alias'] || false
     index = ENV['index']
     if not index then
       raise "Missing required argument 'index'"
@@ -58,6 +59,12 @@ namespace :elasticsearch do
 
       Environment.client.indices.put_mapping index: index, type: mapping, body: mapping_config
       puts "Created #{mapping}"
+    end
+
+    # Optionally, alias the new index to both read and write.
+    if also_alias
+      change_alias Environment.config['elasticsearch']['index_read'], index
+      change_alias Environment.config['elasticsearch']['index_write'], index
     end
   end
 

--- a/tasks/elasticsearch.rake
+++ b/tasks/elasticsearch.rake
@@ -7,37 +7,16 @@ require 'json'
 namespace :elasticsearch do
 
   # options:
-  #   log - show HTTP requests and responses
-  task client: [:environment] do
-    if $config['elasticsearch']['host'].nil?
-      fail "The elasticsearch server's hostname is not set in the configuration file"
-    end
-    if $config['elasticsearch']['port'].nil?
-      fail "The elasticsearch server's port number is not set in the configuration file"
-    end
-    if $config['elasticsearch']['index_read'].nil?
-      fail "The elasticsearch server's index name for reading is not set in the configuration file"
-    end
-    if $config['elasticsearch']['index_write'].nil?
-      fail "The elasticsearch server's index name for writing is not set in the configuration file"
-    end
-
-    log = ENV['log'] || false
-    endpoint = "http://#{$config['elasticsearch']['host']}:#{$config['elasticsearch']['port']}"
-    $elasticsearch_client = Elasticsearch::Client.new url: endpoint, log: log
-  end
-
-  # options:
   #   only - only one mapping, please
   #   force - delete the mapping first (okay...)
   #   index - which index to initialize
   desc "Initialize ES mappings"
-  task init: [:environment, :client] do
+  task init: :environment do
     single = ENV['only'] || nil
     force = ENV['force'] || false
     index = ENV['index']
     if not index then
-      raise "Missing required argunent 'index'"
+      raise "Missing required argument 'index'"
     end
 
     mappings = single ? [single] : Dir.glob('config/mappings/*.json').map {|dir| File.basename dir, File.extname(dir)}
@@ -45,52 +24,46 @@ namespace :elasticsearch do
     index_settings = JSON.parse(File.read('config/index.json'))
 
     if force
-      if $elasticsearch_client.indices.exists index: index
-        $elasticsearch_client.indices.delete index: index
-
+      if Environment.client.indices.exists index: index
+        Environment.client.indices.delete index: index
         puts "Deleted index"
       end
-      $elasticsearch_client.indices.create index: index
-      $elasticsearch_client.cluster.health wait_for_status: 'green'
-
+      Environment.client.indices.create index: index
+      Environment.client.cluster.health wait_for_status: 'green'
       puts "Created index"
     else
-      if $elasticsearch_client.indices.exists index: index
+      if Environment.client.indices.exists index: index
         puts "Index already exists"
       else
-        $elasticsearch_client.indices.create index: index
-        $elasticsearch_client.cluster.health wait_for_status: 'green'
-
+        Environment.client.indices.create index: index
+        Environment.client.cluster.health wait_for_status: 'green'
         puts "Created index"
       end
     end
 
-    $elasticsearch_client.indices.close index: index
-
+    Environment.client.indices.close index: index
     puts "Closed index"
 
     begin
-      $elasticsearch_client.indices.put_settings index: index, body: index_settings
-
+      Environment.client.indices.put_settings index: index, body: index_settings
       puts "Configured index"
     ensure
-      $elasticsearch_client.indices.open index: index
-
+      Environment.client.indices.open index: index
       puts "Opened index"
     end
 
     mappings.each do |mapping|
       mapping_raw = File.read("config/mappings/#{mapping}.json")
       mapping_config = JSON.parse(mapping_raw)
-      $elasticsearch_client.indices.put_mapping index: index, type: mapping, body: mapping_config
 
+      Environment.client.indices.put_mapping index: index, type: mapping, body: mapping_config
       puts "Created #{mapping}"
     end
   end
 
   desc "List all indices and their aliases"
-  task list: [:environment, :client] do
-    for index, aliases in $elasticsearch_client.indices.get_aliases do
+  task list: :environment do
+    for index, aliases in Environment.client.indices.get_aliases do
       if !(index.start_with? ".") then
         puts "#{index}, #{aliases['aliases'].length} aliases"
         for alias_, options in aliases['aliases'] do
@@ -106,25 +79,25 @@ namespace :elasticsearch do
 
   def change_alias(name, index)
     actions = []
-    if $elasticsearch_client.indices.exists_alias name: name then
-      old = $elasticsearch_client.indices.get_alias name: name
+    if Environment.client.indices.exists_alias name: name then
+      old = Environment.client.indices.get_alias name: name
       for old_index, _ in old do
         actions.push({ remove: { index: old_index, alias: name } })
       end
     end
     actions.push({ add: { index: index, alias: name } })
-    $elasticsearch_client.indices.update_aliases body: { actions: actions }
+    Environment.client.indices.update_aliases body: { actions: actions }
     puts "Aliased #{name} to point to #{index}"
   end
 
   desc "Create or update the reading index alias"
   # options:
   #   index - which index to point to
-  task alias_read: [:environment, :client] do
-    alias_name = $config['elasticsearch']['index_read']
+  task alias_read: :environment do
+    alias_name = Environment.config['elasticsearch']['index_read']
     index = ENV['index']
     if not index then
-      raise "Missing required argunent 'index'"
+      raise "Missing required argument 'index'"
     end
     change_alias alias_name, index
   end
@@ -132,11 +105,11 @@ namespace :elasticsearch do
   desc "Create or update the writing index alias"
   # options:
   #   index - which index to point to
-  task alias_write: [:environment, :client] do
-    alias_name = $config['elasticsearch']['index_write']
+  task alias_write: :environment do
+    alias_name = Environment.config['elasticsearch']['index_write']
     index = ENV['index']
     if not index then
-      raise "Missing required argunent 'index'"
+      raise "Missing required argument 'index'"
     end
     change_alias alias_name, index
   end
@@ -144,18 +117,19 @@ namespace :elasticsearch do
   desc "Delete an index"
   # options:
   #   index - which index to delete
-  task delete: [:environment, :client] do
+  task delete: :environment do
     index = ENV['index']
     if not index then
-      raise "Missing required argunent 'index'"
+      raise "Missing required argument 'index'"
     end
 
-    aliases =  [$config['elasticsearch']['index_read'], $config['elasticsearch']['index_write']]
-    if $elasticsearch_client.indices.get_alias(name: aliases.join(","), index: index).length > 0 then
+    aliases =  [Environment.config['elasticsearch']['index_read'], Environment.config['elasticsearch']['index_write']]
+    if Environment.client.indices.get_alias(name: aliases.join(","), index: index).length > 0 then
       raise "That index is currently used by an alias, reassign aliases before deleting the index"
     end
 
-    $elasticsearch_client.indices.delete index: index
+    Environment.client.indices.delete index: index
+    Environment.client.cluster.health wait_for_status: 'green'
     puts "Deleted index #{index}"
   end
 end

--- a/tasks/sitemap.rake
+++ b/tasks/sitemap.rake
@@ -5,12 +5,12 @@ namespace :sitemap do
     require 'json'
     require "cgi"
 
-    ping_google = (!$config['sitemap'].nil?) && ($config['sitemap']['ping_google'] ? true : false)
-    ping_bing = (!$config['sitemap'].nil?) && ($config['sitemap']['ping_bing'] ? true : false)
-    ping_yahoo = (!$config['sitemap'].nil?) && ($config['sitemap']['ping_yahoo'] ? true : false)
-    yahoo_app_id = ($config['sitemap'].nil?) ? nil : $config['sitemap']['yahoo_app_id']
-    ping_ask = (!$config['sitemap'].nil?) && ($config['sitemap']['ping_ask'] ? true : false)
-    ping_yandex = (!$config['sitemap'].nil?) && ($config['sitemap']['ping_yandex'] ? true : false)
+    ping_google = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_google'] ? true : false)
+    ping_bing = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_bing'] ? true : false)
+    ping_yahoo = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_yahoo'] ? true : false)
+    yahoo_app_id = (Environment.config['sitemap'].nil?) ? nil : Environment.config['sitemap']['yahoo_app_id']
+    ping_ask = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_ask'] ? true : false)
+    ping_yandex = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_yandex'] ? true : false)
 
     BigSitemap.generate(
       base_url: "https://oversight.garden/",
@@ -37,7 +37,7 @@ namespace :sitemap do
       end
 
       # Add each report landing page
-      data_dir = $config['inspectors']['data']
+      data_dir = Environment.config['inspectors']['data']
       Dir.foreach(data_dir) do |inspector|
         next if inspector == "." or inspector == ".."
         next if not File.directory?(File.join(data_dir, inspector))

--- a/test/status_codes.js
+++ b/test/status_codes.js
@@ -10,7 +10,7 @@ describe('homepage', function() {
     var baseURL = server.getBaseURL();
     request(baseURL, function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -21,7 +21,7 @@ describe('reports page, all', function() {
     var baseURL = server.getBaseURL();
     request(baseURL + '/reports', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -32,7 +32,7 @@ describe('reports page, search results', function() {
     var baseURL = server.getBaseURL();
     request(baseURL + '/reports?query=audit', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -43,7 +43,7 @@ describe('reports ATOM feed, all', function() {
     var baseURL = server.getBaseURL();
     request(baseURL + '/reports.xml', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -54,7 +54,7 @@ describe('reports ATOM feed, search results', function() {
     var baseURL = server.getBaseURL();
     request(baseURL + '/reports.xml?query=audit', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -65,7 +65,7 @@ describe('inspectors page', function() {
     var baseURL = server.getBaseURL();
     request(baseURL + '/inspectors', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -74,9 +74,9 @@ describe('inspectors page', function() {
 describe('inspector page', function() {
   it('is OK', function(done) {
     var baseURL = server.getBaseURL();
-    request(baseURL + '/inspector/denali', function(error, response, body) {
+    request(baseURL + '/inspectors/denali', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });
@@ -85,9 +85,9 @@ describe('inspector page', function() {
 describe('report page', function() {
   it('is OK', function(done) {
     var baseURL = server.getBaseURL();
-    request(baseURL + '/report/denali/DCOIG-15-013-M', function(error, response, body) {
+    request(baseURL + '/reports/denali/DCOIG-15-013-M', function(error, response, body) {
       assert.ifError(error);
-      assert.equal(response.statusCode, 200);
+      assert.equal(200, response.statusCode);
       done();
     });
   });


### PR DESCRIPTION
This removes the use of Ruby global variables in favor of an `Environment` class with a few magic class methods. The encapsulation is easier to manage and predict, and I think it cleans up the code a bit.

I also moved the Elasticsearch client creation out of `rake` altogether and into `config/environment.rb`, so that that can all be loaded in in the `:environment` task, and the dependencies by other tasks can just be on `:environment`.