### PR TITLE
Basic blogging engine, see README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,26 @@ Sitemaps can be generated with the following rake task:
 rake sitemap:generate
 ```
 
+### Blogging
+
+There is a blogging system, powered by the
+[Wintersmith](https://github.com/jnordberg/wintersmith) static site generator,
+built into the site itself. By default, it can be easily used to create static
+pages ("blog posts") under oversight.garden/blog/. Here are the steps:
+
+1. Install the wintersmith CLI tool globally: `npm install -g wintersmith`
+1. Make sure `wintersmith-ejs` is installed in node_modules. It should be part
+   of package.json
+1. Create a blog post markdown file in `./blog/` Something like
+   ./blog/my-first-post.md. Make sure it has YAML front matter (you can look at
+   existing posts for how to set this up). The `filename` key in the frontmatter
+   can be used to specify a final URL for the post that is different from its
+   file name (eg "filename: superblog.html" will make my-first-post.md be served
+   as oversight.garden/blog/superblog.html).
+1. Run the wintersmith generator with this command: `$ wintersmith build --config=blog-config.js`
+1. Commit the new file(s) in ./public/blog to git/github.
+1. Deploy the site as normal
+
 ### Public domain
 
 This project is [dedicated to the public domain](LICENSE). As spelled out in [CONTRIBUTING](CONTRIBUTING.md):

--- a/blog-config.js
+++ b/blog-config.js
@@ -1,0 +1,21 @@
+{
+  "locals": {
+    "req": null,
+    "helpers": {
+      "boot_time": 1234
+    }
+  },
+  "templates": "./views",
+  "contents": "./blog",
+  "output": "./public/blog/",
+  "plugins": [
+    "wintersmith-ejs"
+  ],
+  "jade": {
+    "pretty": true
+  },
+  "markdown": {
+    "smartLists": true,
+    "smartypants": true
+  }
+}

--- a/blog/2016-04-16-blogging-works.md
+++ b/blog/2016-04-16-blogging-works.md
@@ -1,0 +1,22 @@
+---
+title: Blogging works!
+date: 2016-04-16 18:00
+template: blog-post.ejs
+filename: /blogging-works.html
+---
+
+# This is a sample blog page
+
+The blogging template, views/blog-post.ejs, doesn't currently do anything with
+the post's title or date. The title "This is a sample blog page" is part of the
+page itself.
+
+## Publishing a blog post.
+
+Instructions will be in the README.md file of the main repository. The basic
+idea is that you create a file with your content, run the Wintersmith build
+command, and then commit the static files to the `public/blog/` directory.
+
+## That's all for now
+
+Happy blogging!

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "js-yaml": "^3.5.2",
     "method-override": "^2.3.5",
     "minimist": "^1.2.0",
-    "numeral": "^1.5.3"
+    "numeral": "^1.5.3",
+    "wintersmith-ejs": "^0.1.4"
   },
   "devDependencies": {
     "intercept-stdout": "^0.1.2",

--- a/public/blog/2016-04-16-blogging-works.html
+++ b/public/blog/2016-04-16-blogging-works.html
@@ -1,0 +1,4 @@
+<h1 id="look-">Look!</h1>
+<p>Blogging works!</p>
+<h2 id="we-re-so-happy">We’re so happy</h2>
+<p>We just want to link you to <a href="https://google.com">Google</a>!</p>

--- a/public/blog/blogging-works.html
+++ b/public/blog/blogging-works.html
@@ -39,7 +39,7 @@
 
 <link rel="shortcut icon" href="/favicon.png" />
 
-  <link rel="canonical" href="https://oversight.garden/blogging-works.html" />
+  <link rel="canonical" href="https://oversight.garden/blog/blogging-works.html" />
 
 
 
@@ -76,7 +76,7 @@
 
 <article>
   <h1 id="this-is-a-sample-blog-page">This is a sample blog page</h1>
-<p>The blogging template, views/blog-post.ejs, doesn’t currently do anythign with
+<p>The blogging template, views/blog-post.ejs, doesn’t currently do anything with
 the post’s title or date. The title “This is a sample blog page” is part of the
 page itself.</p>
 <h2 id="publishing-a-blog-post-">Publishing a blog post.</h2>

--- a/public/blog/blogging-works.html
+++ b/public/blog/blogging-works.html
@@ -12,21 +12,14 @@
 <html lang="en">
 <head>
 
-<% if ((typeof(report) != "undefined") && report) { %>
-    <title>
-        <%= helpers.inspector_info(report.inspector).name %> | <%= report.agency_name %> | <%= report.title %>
-    </title>
-    <meta name="og:title" content="<%= helpers.inspector_info(report.inspector).name %> | <%= report.agency_name %> | <%= report.title %>" />
-    <meta name="description" content="<%= report.title %>" />
-    <meta name="og:description" content="<%= report.title %>" />
-<% } else { %>
+
     <title>
         oversight.garden | Collecting the oversight community's work in one place.
     </title>
     <meta name="og:title" content="oversight.garden">
     <meta name="description" content="Collecting the oversight community's work in one place." />
     <meta name="og:description" content="Collecting the oversight community's work in one place." />
-<% } %>
+
 
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -45,20 +38,15 @@
 <link rel="vcs-git" href="https://github.com/konklone/oversight.garden" title="code for oversight.garden" />
 
 <link rel="shortcut icon" href="/favicon.png" />
-<% if (req) { %>
-  <link rel="canonical" href="https://oversight.garden<%= req.originalUrl %>" />
-<% } else { %>
-  <link rel="canonical" href="https://oversight.garden<%= page.url %>" />
-<% } %>
 
-<% if (req && req.originalUrl.startsWith("/reports")) { -%>
-  <link rel="alternate" type="application/atom+xml" title="Search Results" href="<%= req.originalUrl.replace("/reports", "/reports.xml") %>" />
-<% } -%>
+  <link rel="canonical" href="https://oversight.garden/blogging-works.html" />
+
+
 
 <meta name="twitter:card" content="summary" />
 
 <link rel='stylesheet' type='text/css' href='/css/fonts.css' />
-<link rel="stylesheet" type="text/css" href="/css/main.css?<%= helpers.boot_time %>" />
+<link rel="stylesheet" type="text/css" href="/css/main.css?1234" />
 
 </head>
 <body>
@@ -85,3 +73,43 @@
         </ul>
     </nav>
 </header>
+
+<article>
+  <h1 id="this-is-a-sample-blog-page">This is a sample blog page</h1>
+<p>The blogging template, views/blog-post.ejs, doesn’t currently do anythign with
+the post’s title or date. The title “This is a sample blog page” is part of the
+page itself.</p>
+<h2 id="publishing-a-blog-post-">Publishing a blog post.</h2>
+<p>Instructions will be in the README.md file of the main repository. The basic
+idea is that you create a file with your content, run the Wintersmith build
+command, and then commit the static files to the <code>public/blog/</code> directory.</p>
+<h2 id="that-s-all-for-now">That’s all for now</h2>
+<p>Happy blogging!</p>
+
+</article>
+
+</main>
+
+<footer class="footer">
+      <p>
+          oversight.garden is a project of <a href="https://twitter.com/konklone">Eric Mill</a>, <a href="https://twitter.com/divergentdave">David Cook</a>, and <a href="/humans.txt">other wonderful humans</a>. oversight.garden is free and <a href="https://github.com/konklone/oversight.garden">open source</a>. Original writing licensed under <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY 4.0</a>.
+      </p>
+</footer>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-252618-18', 'oversight.garden');
+
+  // Anonymize user IPs (cut off the last triplet).
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
+
+  ga('send', 'pageview');
+</script>
+
+</body>
+</html>

--- a/views/blog-post.ejs
+++ b/views/blog-post.ejs
@@ -1,0 +1,7 @@
+<% include layout/header.html -%>
+
+<article>
+  <%- page.html %>
+</article>
+
+<% include layout/footer.html -%>

--- a/views/layout/header.html
+++ b/views/layout/header.html
@@ -48,7 +48,7 @@
 <% if (req) { %>
   <link rel="canonical" href="https://oversight.garden<%= req.originalUrl %>" />
 <% } else { %>
-  <link rel="canonical" href="https://oversight.garden<%= page.url %>" />
+  <link rel="canonical" href="https://oversight.garden/blog<%= page.url %>" />
 <% } %>
 
 <% if (req && req.originalUrl.startsWith("/reports")) { -%>


### PR DESCRIPTION
From the README included with this CL:

There is a blogging system, powered by the
[Wintersmith](https://github.com/jnordberg/wintersmith) static site generator,
built into the site itself. By default, it can be easily used to create static
pages ("blog posts") under oversight.garden/blog/. Here are the steps:

1. Install the wintersmith CLI tool globally: `npm install -g wintersmith`
1. Make sure `wintersmith-ejs` is installed in node_modules. It should be part
   of package.json
1. Create a blog post markdown file in `./blog/` Something like
   ./blog/my-first-post.md. Make sure it has YAML front matter (you can look at
   existing posts for how to set this up). The `filename` key in the frontmatter
   can be used to specify a final URL for the post that is different from its
   file name (eg "filename: superblog.html" will make my-first-post.md be served
   as oversight.garden/blog/superblog.html).
1. Run the wintersmith generator with this command: `$ wintersmith build --config=blog-config.js`
1. Commit the new file(s) in ./public/blog to git/github.
1. Deploy the site as normal