### PR TITLE
Indexing: fork worker processes

### DIFF
--- a/app/boot.js
+++ b/app/boot.js
@@ -5,9 +5,6 @@ var config = require("../config/config"),
     fs = require("fs"),
     yaml = require('js-yaml');
 
-var featured_path = "config/featured.yaml";
-var featured = yaml.safeLoad(fs.readFileSync(featured_path));
-
 module.exports = {
   es: new elasticsearch.Client({
     apiVersion: "1.7",
@@ -16,9 +13,6 @@ module.exports = {
       port: config.elasticsearch.port
     },
     // log: 'debug'
-  }),
-
-  featured: featured
-
+  })
 };
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1922,15 +1922,15 @@
                       "from": "lodash.padstart@>=4.1.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.2.0.tgz"
                     },
-                    "lodash.repeat": {
-                      "version": "4.0.0",
-                      "from": "lodash.repeat@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
-                    },
                     "lodash.tostring": {
                       "version": "4.1.1",
                       "from": "lodash.tostring@>=4.0.0 <5.0.0",
                       "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.1.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "4.0.0",
+                      "from": "lodash.repeat@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.0.0.tgz"
                     }
                   }
                 }
@@ -2672,6 +2672,25 @@
           "version": "1.3.3",
           "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+        }
+      }
+    },
+    "worker-farm": {
+      "version": "1.3.1",
+      "from": "worker-farm@latest",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
+      "dependencies": {
+        "errno": {
+          "version": "0.1.4",
+          "from": "errno@>=0.1.1 <0.2.0-0",
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+          "dependencies": {
+            "prr": {
+              "version": "0.0.0",
+              "from": "prr@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+            }
+          }
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -47,11 +47,6 @@
       "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
     },
-    "bl": {
-      "version": "1.0.0",
-      "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
-    },
     "body-parser": {
       "version": "1.14.2",
       "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
@@ -235,17 +230,17 @@
     },
     "elasticsearch": {
       "version": "11.0.0",
-      "from": "elasticsearch@>=11.0.0 <12.0.0",
+      "from": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-11.0.0.tgz",
       "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-11.0.0.tgz",
       "dependencies": {
         "promise": {
           "version": "7.1.1",
-          "from": "promise@>=7.1.1 <8.0.0",
+          "from": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
           "dependencies": {
             "asap": {
               "version": "2.0.3",
-              "from": "asap@>=2.0.3 <2.1.0",
+              "from": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
             }
           }
@@ -372,11 +367,6 @@
       "version": "2.0.0",
       "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
-    },
-    "hawk": {
-      "version": "3.1.0",
-      "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.0.tgz"
     },
     "hoek": {
       "version": "2.16.3",
@@ -589,11 +579,6 @@
       "from": "https://registry.npmjs.org/numeral/-/numeral-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/numeral/-/numeral-1.5.3.tgz"
     },
-    "oauth-sign": {
-      "version": "0.8.0",
-      "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-    },
     "on-finished": {
       "version": "2.3.0",
       "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -738,79 +723,79 @@
     },
     "wintersmith": {
       "version": "2.3.1",
-      "from": "wintersmith@latest",
+      "from": "https://registry.npmjs.org/wintersmith/-/wintersmith-2.3.1.tgz",
       "resolved": "https://registry.npmjs.org/wintersmith/-/wintersmith-2.3.1.tgz",
       "dependencies": {
         "chokidar": {
           "version": "1.4.3",
-          "from": "chokidar@>=1.4.2 <1.5.0",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.3.tgz",
           "dependencies": {
             "anymatch": {
               "version": "1.3.0",
-              "from": "anymatch@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
               "dependencies": {
                 "arrify": {
                   "version": "1.0.1",
-                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                 },
                 "micromatch": {
                   "version": "2.3.7",
-                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
                   "dependencies": {
                     "arr-diff": {
                       "version": "2.0.0",
-                      "from": "arr-diff@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                       "dependencies": {
                         "arr-flatten": {
                           "version": "1.0.1",
-                          "from": "arr-flatten@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                         }
                       }
                     },
                     "array-unique": {
                       "version": "0.2.1",
-                      "from": "array-unique@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                     },
                     "braces": {
                       "version": "1.8.3",
-                      "from": "braces@>=1.8.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
                       "dependencies": {
                         "expand-range": {
                           "version": "1.8.1",
-                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                           "dependencies": {
                             "fill-range": {
                               "version": "2.2.3",
-                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                               "dependencies": {
                                 "is-number": {
                                   "version": "2.1.0",
-                                  "from": "is-number@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                 },
                                 "isobject": {
                                   "version": "2.0.0",
-                                  "from": "isobject@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz"
                                 },
                                 "randomatic": {
                                   "version": "1.1.5",
-                                  "from": "randomatic@>=1.1.3 <2.0.0",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -819,114 +804,114 @@
                         },
                         "preserve": {
                           "version": "0.2.0",
-                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                         },
                         "repeat-element": {
                           "version": "1.1.2",
-                          "from": "repeat-element@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                         }
                       }
                     },
                     "expand-brackets": {
                       "version": "0.1.5",
-                      "from": "expand-brackets@>=0.1.4 <0.2.0",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                       "dependencies": {
                         "is-posix-bracket": {
                           "version": "0.1.1",
-                          "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                         }
                       }
                     },
                     "extglob": {
                       "version": "0.3.2",
-                      "from": "extglob@>=0.3.1 <0.4.0",
+                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                     },
                     "filename-regex": {
                       "version": "2.0.0",
-                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                     },
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     },
                     "kind-of": {
                       "version": "3.0.2",
-                      "from": "kind-of@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                       "dependencies": {
                         "is-buffer": {
                           "version": "1.1.3",
-                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                         }
                       }
                     },
                     "normalize-path": {
                       "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     },
                     "object.omit": {
                       "version": "2.0.0",
-                      "from": "object.omit@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                       "dependencies": {
                         "for-own": {
                           "version": "0.1.4",
-                          "from": "for-own@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
                           "dependencies": {
                             "for-in": {
                               "version": "0.1.5",
-                              "from": "for-in@>=0.1.5 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz",
                               "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.5.tgz"
                             }
                           }
                         },
                         "is-extendable": {
                           "version": "0.1.1",
-                          "from": "is-extendable@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                         }
                       }
                     },
                     "parse-glob": {
                       "version": "3.0.4",
-                      "from": "parse-glob@>=3.0.4 <4.0.0",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                       "dependencies": {
                         "glob-base": {
                           "version": "0.3.0",
-                          "from": "glob-base@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                         },
                         "is-dotfile": {
                           "version": "1.0.2",
-                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                         }
                       }
                     },
                     "regex-cache": {
                       "version": "0.4.3",
-                      "from": "regex-cache@>=0.4.2 <0.5.0",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                       "dependencies": {
                         "is-equal-shallow": {
                           "version": "0.1.3",
-                          "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                         },
                         "is-primitive": {
                           "version": "2.0.0",
-                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                         }
                       }
@@ -937,51 +922,51 @@
             },
             "async-each": {
               "version": "1.0.0",
-              "from": "async-each@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
             },
             "glob-parent": {
               "version": "2.0.0",
-              "from": "glob-parent@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
             },
             "is-binary-path": {
               "version": "1.0.1",
-              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
               "dependencies": {
                 "binary-extensions": {
                   "version": "1.4.0",
-                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
                 }
               }
             },
             "is-glob": {
               "version": "2.0.1",
-              "from": "is-glob@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
               "dependencies": {
                 "is-extglob": {
                   "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 }
               }
             },
             "readdirp": {
               "version": "2.0.0",
-              "from": "readdirp@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "4.1.3",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.3.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.10 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
                 }
               }
@@ -990,42 +975,42 @@
         },
         "coffee-script": {
           "version": "1.10.0",
-          "from": "coffee-script@>=1.10.0 <1.11.0",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz"
         },
         "highlight.js": {
           "version": "9.2.0",
-          "from": "highlight.js@>=9.2.0 <9.3.0",
+          "from": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.2.0.tgz",
           "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.2.0.tgz"
         },
         "jade": {
           "version": "1.11.0",
-          "from": "jade@>=1.11.0 <1.12.0",
+          "from": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
           "resolved": "https://registry.npmjs.org/jade/-/jade-1.11.0.tgz",
           "dependencies": {
             "character-parser": {
               "version": "1.2.1",
-              "from": "character-parser@1.2.1",
+              "from": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
             },
             "clean-css": {
               "version": "3.4.12",
-              "from": "clean-css@>=3.1.9 <4.0.0",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
               "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.12.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.0 <2.9.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "source-map@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -1034,39 +1019,39 @@
             },
             "commander": {
               "version": "2.6.0",
-              "from": "commander@>=2.6.0 <2.7.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
               "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
             },
             "constantinople": {
               "version": "3.0.2",
-              "from": "constantinople@>=3.0.1 <3.1.0",
+              "from": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.2.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "2.7.0",
-                  "from": "acorn@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                 }
               }
             },
             "jstransformer": {
               "version": "0.0.2",
-              "from": "jstransformer@0.0.2",
+              "from": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-0.0.2.tgz",
               "dependencies": {
                 "is-promise": {
                   "version": "2.1.0",
-                  "from": "is-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz"
                 },
                 "promise": {
                   "version": "6.1.0",
-                  "from": "promise@>=6.0.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
                   "dependencies": {
                     "asap": {
                       "version": "1.0.0",
-                      "from": "asap@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
                     }
                   }
@@ -1075,63 +1060,63 @@
             },
             "transformers": {
               "version": "2.1.0",
-              "from": "transformers@2.1.0",
+              "from": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
               "dependencies": {
                 "promise": {
                   "version": "2.0.0",
-                  "from": "promise@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
                   "dependencies": {
                     "is-promise": {
                       "version": "1.0.1",
-                      "from": "is-promise@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
                     }
                   }
                 },
                 "css": {
                   "version": "1.0.8",
-                  "from": "css@>=1.0.8 <1.1.0",
+                  "from": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
                   "dependencies": {
                     "css-parse": {
                       "version": "1.0.4",
-                      "from": "css-parse@1.0.4",
+                      "from": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
                     },
                     "css-stringify": {
                       "version": "1.0.5",
-                      "from": "css-stringify@1.0.5",
+                      "from": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
                     }
                   }
                 },
                 "uglify-js": {
                   "version": "2.2.5",
-                  "from": "uglify-js@>=2.2.5 <2.3.0",
+                  "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
                   "dependencies": {
                     "source-map": {
                       "version": "0.1.43",
-                      "from": "source-map@>=0.1.7 <0.2.0",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                       "dependencies": {
                         "amdefine": {
                           "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                         }
                       }
                     },
                     "optimist": {
                       "version": "0.3.7",
-                      "from": "optimist@>=0.3.5 <0.4.0",
+                      "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
                       "dependencies": {
                         "wordwrap": {
                           "version": "0.0.3",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
                         }
                       }
@@ -1142,110 +1127,110 @@
             },
             "uglify-js": {
               "version": "2.6.2",
-              "from": "uglify-js@>=2.4.19 <3.0.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.2.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
-                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.3",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "1.0.3",
-                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.3.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.3 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.2",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.3",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.3.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -1254,19 +1239,19 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     }
                   }
@@ -1275,27 +1260,27 @@
             },
             "void-elements": {
               "version": "2.0.1",
-              "from": "void-elements@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz"
             },
             "with": {
               "version": "4.0.3",
-              "from": "with@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
               "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
               "dependencies": {
                 "acorn": {
                   "version": "1.2.2",
-                  "from": "acorn@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                 },
                 "acorn-globals": {
                   "version": "1.0.9",
-                  "from": "acorn-globals@>=1.0.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "2.7.0",
-                      "from": "acorn@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
                     }
                   }
@@ -1306,58 +1291,58 @@
         },
         "js-yaml": {
           "version": "3.4.6",
-          "from": "js-yaml@>=3.4.6 <3.5.0",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.7",
-              "from": "argparse@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "esprima": {
               "version": "2.7.2",
-              "from": "esprima@>=2.6.0 <3.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
             },
             "inherit": {
               "version": "2.2.3",
-              "from": "inherit@>=2.2.2 <3.0.0",
+              "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
               "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
             }
           }
         },
         "marked": {
           "version": "0.3.5",
-          "from": "marked@>=0.3.5 <0.4.0",
+          "from": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "ncp": {
           "version": "2.0.0",
-          "from": "ncp@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
         },
         "npm": {
           "version": "3.7.5",
-          "from": "npm@>=3.7.3 <3.8.0",
+          "from": "https://registry.npmjs.org/npm/-/npm-3.7.5.tgz",
           "resolved": "https://registry.npmjs.org/npm/-/npm-3.7.5.tgz",
           "dependencies": {
             "abbrev": {
@@ -2626,52 +2611,52 @@
         },
         "rimraf": {
           "version": "2.5.2",
-          "from": "rimraf@>=2.5.2 <2.6.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
         },
         "server-destroy": {
           "version": "1.0.1",
-          "from": "server-destroy@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz"
         },
         "slugg": {
           "version": "1.0.0",
-          "from": "slugg@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/slugg/-/slugg-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/slugg/-/slugg-1.0.0.tgz"
         },
         "winston": {
           "version": "2.1.1",
-          "from": "winston@>=2.1.1 <2.2.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
           "dependencies": {
             "async": {
               "version": "1.0.0",
-              "from": "async@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
             },
             "colors": {
               "version": "1.0.3",
-              "from": "colors@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "pkginfo": {
               "version": "0.3.1",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
@@ -2680,12 +2665,12 @@
     },
     "wintersmith-ejs": {
       "version": "0.1.4",
-      "from": "wintersmith-ejs@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/wintersmith-ejs/-/wintersmith-ejs-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/wintersmith-ejs/-/wintersmith-ejs-0.1.4.tgz",
       "dependencies": {
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "minimist": "^1.2.0",
     "numeral": "^1.5.3",
     "wintersmith": "^2.3.1",
-    "wintersmith-ejs": "^0.1.4"
+    "wintersmith-ejs": "^0.1.4",
+    "worker-farm": "^1.3.1"
   },
   "devDependencies": {
     "intercept-stdout": "^0.1.2",

--- a/tasks/inspectors-worker.js
+++ b/tasks/inspectors-worker.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var fs = require('fs'),
+    path = require('path');
+
+var config = require("../config/config"),
+    boot = require("../app/boot"),
+    es = boot.es,
+    featured = boot.featured;
+
+// load a report from disk, put it into elasticsearch
+function loadReport(details, done) {
+  var base_path = details.base_path,
+      inspector = details.inspector,
+      year = details.year,
+      report_id = details.report_id;
+  console.log("[" + inspector + "][" + year + "][" + report_id + "]");
+
+  console.log("\tLoading JSON from disk...");
+  var datafile = path.join(base_path, inspector, year.toString(), report_id, "report.json");
+  if (!fs.existsSync(datafile)) {
+    console.error("ERROR: JSON missing, report is probably a bad URL.");
+    return done();
+  }
+  var json = fs.readFileSync(datafile);
+  if (!json || json.length <= 0) return done(null);
+  var data = JSON.parse(json);
+
+  console.log("\tLoading text from disk...");
+  var textfile = path.join(base_path, inspector, year.toString(), report_id, "report.txt");
+  if (fs.existsSync(textfile))
+    data.text = fs.readFileSync(textfile).toString();
+
+  // and this is for IG reports
+  data.source = "igs";
+
+  // if it's been manually flagged as featured, mark it as such
+  if (featured[inspector] && featured[inspector][report_id]) {
+    data.featured = featured[inspector][report_id];
+    data.is_featured = true;
+  } else
+    data.is_featured = false;
+
+  // Actually load into Elasticsearch
+  console.log("\tIndexing into Elasticsearch...");
+  es.index({
+    index: config.elasticsearch.index_write,
+    type: 'reports',
+    id: inspector + '-' + report_id,
+    body: data
+  }, function(err) {
+    if (err) {
+      done(err);
+    } else {
+      done(null);
+    }
+  });
+}
+
+module.exports = loadReport;

--- a/tasks/inspectors-worker.js
+++ b/tasks/inspectors-worker.js
@@ -5,13 +5,12 @@
 var fs = require('fs'),
     path = require('path');
 
-var config = require("../config/config"),
-    boot = require("../app/boot"),
+var boot = require("../app/boot"),
     es = boot.es,
     featured = boot.featured;
 
 // load a report from disk, put it into elasticsearch
-function loadReport(details, done) {
+function loadReport(details, config, done) {
   var base_path = details.base_path,
       inspector = details.inspector,
       year = details.year,

--- a/tasks/inspectors-worker.js
+++ b/tasks/inspectors-worker.js
@@ -2,12 +2,13 @@
 
 "use strict";
 
-var fs = require('fs'),
-    path = require('path');
+var elasticsearch = require("elasticsearch"),
+    fs = require('fs'),
+    path = require('path'),
+    yaml = require('js-yaml');
 
-var boot = require("../app/boot"),
-    es = boot.es,
-    featured = boot.featured;
+var featured_path = "config/featured.yaml";
+var featured = yaml.safeLoad(fs.readFileSync(featured_path));
 
 // load a report from disk, put it into elasticsearch
 function loadReport(details, config, done) {
@@ -44,6 +45,13 @@ function loadReport(details, config, done) {
 
   // Actually load into Elasticsearch
   console.log("\tIndexing into Elasticsearch...");
+  var es = new elasticsearch.Client({
+    apiVersion: "1.7",
+    host: {
+      host: config.elasticsearch.host,
+      port: config.elasticsearch.port
+    }
+  });
   es.index({
     index: config.elasticsearch.index_write,
     type: 'reports',

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -23,7 +23,7 @@ var config = require("../config/config"),
     farm = workerFarm(require.resolve('./inspectors-worker'));
 
 function loadReportProxy(details, done) {
-  farm(details, function(err) {
+  farm(details, config, function(err) {
     if (err) {
       console.log("\tEr what!!");
       console.log("\t" + err);

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -94,13 +94,7 @@ function ingest(fetch, done) {
   async.eachSeries(fetch, loadReportProxy, function(err) {
     if (err) console.log("Error doing things!!");
 
-    console.log("Refreshing index.");
-    es.indices.refresh(function(err) {
-      if (err) console.log("Error: " + err);
-
-      console.log("All done.");
-      done();
-    });
+    done();
   });
 }
 
@@ -137,6 +131,13 @@ function run(options) {
     }
     ingest(reports_list, function() {
       workerFarm.end(farm);
+
+      console.log("Refreshing index.");
+      es.indices.refresh(function(err) {
+        if (err) console.log("Error: " + err);
+
+        console.log("All done.");
+      });
     });
   });
 }

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -19,8 +19,13 @@ var async = require('async'),
 
 var config = require("../config/config"),
     boot = require("../app/boot"),
-    es = boot.es,
-    farm = workerFarm(require.resolve('./inspectors-worker'));
+    es = boot.es;
+
+var farm = workerFarm({
+  maxCallsPerWorker: 1000,
+  maxConcurrentWorkers: 1,
+  maxRetries: 20
+}, require.resolve('./inspectors-worker'));
 
 function loadReportProxy(details, done) {
   farm(details, config, function(err) {

--- a/tasks/inspectors.js
+++ b/tasks/inspectors.js
@@ -88,7 +88,7 @@ function crawl(options, base_path) {
 function ingest(fetch, done) {
   if (fetch.length === 0) {
     // Don't need to refresh index if there are no reports, exit early
-    return;
+    return done();
   }
 
   async.eachSeries(fetch, loadReportProxy, function(err) {


### PR DESCRIPTION
This fixes #101. Loading text and indexing reports is split off into a worker process, which is managed using the `worker-farm` module. If the worker process crashes during GC, a new process will be started, and the job will be retried. Also, the worker process is stopped and started every 1000 documents, to limit overall memory usage.

Since the worker processes don't inherit command line arguments, I made some additional changes to avoid loading the config file from the worker processes, and I instead pass the config object from the parent process to the worker process.