### PR TITLE
Add configuration option for alternate sitemap dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /config/config.yaml
 /data
 /public/sitemap
+/test/sitemap
 *.log
 *.pyc
 /node_modules

--- a/app.js
+++ b/app.js
@@ -25,6 +25,10 @@ app.enable('trust proxy')
     next();
   });
 
+if (config && config.sitemap && config.sitemap.directory) {
+  app.use('/sitemap', express.static(config.sitemap.directory));
+}
+
 app.use(express.static(__dirname + '/public'));
 
 

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -20,6 +20,7 @@ http:
 
 # automatically ping search engines after generating the sitemap
 sitemap:
+  # directory: /path/to/sitemaps
   ping_google: false
   ping_bing: false
   ping_yahoo: false

--- a/tasks/sitemap.rake
+++ b/tasks/sitemap.rake
@@ -5,6 +5,8 @@ namespace :sitemap do
     require 'json'
     require "cgi"
 
+    directory = (!Environment.config['sitemap'].nil? && !Environment.config['sitemap']['directory'].nil?) ? Environment.config['sitemap']['directory'] : 'public/sitemap'
+
     ping_google = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_google'] ? true : false)
     ping_bing = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_bing'] ? true : false)
     ping_yahoo = (!Environment.config['sitemap'].nil?) && (Environment.config['sitemap']['ping_yahoo'] ? true : false)
@@ -14,7 +16,7 @@ namespace :sitemap do
 
     BigSitemap.generate(
       base_url: "https://oversight.garden/",
-      document_root: "public/sitemap",
+      document_root: directory,
       url_path: "sitemap",
       ping_google: ping_google,
       ping_bing: ping_bing,

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -9,3 +9,6 @@ elasticsearch:
 
 http:
   port: 3000
+
+sitemap:
+  directory: test/sitemap


### PR DESCRIPTION
This adds a config option to change where the sitemap is stored to and loaded from. This will be helpful for #103.