### PR TITLE
Rewrite fabfile.py for new infrastructure

### DIFF
--- a/app/boot.js
+++ b/app/boot.js
@@ -15,7 +15,7 @@ var esConfig = {
   // log: 'debug'
 };
 
-if (config.aws) {
+if (config.aws && config.elasticsearch.host != "127.0.0.1") {
   esConfig.connectionClass = require('http-aws-es');
   esConfig.amazonES = {
     region: config.aws.region,


### PR DESCRIPTION
- Look up hostname using AWS API
- Set username in script, don't need ~/.ssh/config any more
- Clone over HTTPS, because instance doesn't have any SSH deploy key
- Add Node/Ruby version managers to commands as appropriate
- Also run `bundle install` alongside `npm install`
- Build blog inside `current_path` when run alone and inside
  `version_path` when run during deploy
- Always cd to working directory before `forever` commands