### PR TITLE
Server, patch thyself

### DIFF
--- a/tasks/scraper_user_data
+++ b/tasks/scraper_user_data
@@ -11,6 +11,10 @@ apt-get update
 apt-get install -y awscli git libxml2-dev libxslt1-dev xpdf python3-pip make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils python3-yaml
 pip3 install virtualenvwrapper
 
+sed -i 's/APT::Periodic::Download-Upgradeable-Packages "0";/APT::Periodic::Download-Upgradeable-Packages "1";/' /etc/apt/apt.conf.d/10periodic
+sed -i 's/APT::Periodic::AutocleanInterval "0";/APT::Periodic::AutocleanInterval "7";/' /etc/apt/apt.conf.d/10periodic
+echo 'APT::Periodic::Unattended-Upgrade "1";' >> /etc/apt/apt.conf.d/10periodic
+
 sudo -u ubuntu git clone https://github.com/sstephenson/rbenv.git /home/ubuntu/.rbenv
 sudo -u ubuntu git clone https://github.com/sstephenson/ruby-build.git /home/ubuntu/.rbenv/plugins/ruby-build
 echo 'export PATH=$HOME/.rbenv/bin:$PATH' | sudo -u ubuntu tee -a /home/ubuntu/.bashrc

--- a/tasks/web_user_data
+++ b/tasks/web_user_data
@@ -6,6 +6,10 @@ echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDeU5tdzfd94DgooUP8JhvDxb0+Cf97cu/zZl
 apt-get update
 apt-get install -y awscli git nginx autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev python3-yaml
 
+sed -i 's/APT::Periodic::Download-Upgradeable-Packages "0";/APT::Periodic::Download-Upgradeable-Packages "1";/' /etc/apt/apt.conf.d/10periodic
+sed -i 's/APT::Periodic::AutocleanInterval "0";/APT::Periodic::AutocleanInterval "7";/' /etc/apt/apt.conf.d/10periodic
+echo 'APT::Periodic::Unattended-Upgrade "1";' >> /etc/apt/apt.conf.d/10periodic
+
 sudo -u ubuntu git clone https://github.com/sstephenson/rbenv.git /home/ubuntu/.rbenv
 sudo -u ubuntu git clone https://github.com/sstephenson/ruby-build.git /home/ubuntu/.rbenv/plugins/ruby-build
 echo 'export PATH=$HOME/.rbenv/bin:$PATH' | sudo -u ubuntu tee -a /home/ubuntu/.bashrc


### PR DESCRIPTION
This will rewrite configuration files to automatically install updates. By default, the AMIs already have `unattended-upgrades` installed, but it just updates package lists daily. This will also download packages and upgrade them daily, plus run autoclean weekly. (as recommended at https://help.ubuntu.com/lts/serverguide/automatic-updates.html) The default configuration will only automatically install package updates in `xenial-security`. I've already run the three new lines in a root shell on both currently running servers. I'm going to check back in a week or so on `/var/log/unattended-upgrades/` to see if things are working.