### PR TITLE
Upgrade node version, track with LTS Boron

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Elasticsearch is used for text search and as a primary datastore.
 
 #### Installing dependencies
 
-* Install [Node](https://nodejs.org/) version 4.x or higher.
+* Install [Node](https://nodejs.org/) version 6 or higher.
 * Install [Elasticsearch](https://elastic.co) version 2.1 or higher.
 * Install [Ruby](https://www.ruby-lang.org/en/) 2.2 or higher.
 * Then install Ruby dependencies:

--- a/tasks/scraper_user_data
+++ b/tasks/scraper_user_data
@@ -71,8 +71,8 @@ END
 sudo -u ubuntu bash <<'END'
 export NVM_DIR=$HOME/.nvm
 source $NVM_DIR/nvm.sh
-nvm install 4.4.7
-nvm alias default 4.4.7
+nvm install lts/boron
+nvm alias default lts/boron
 npm install --production
 END
 

--- a/tasks/web_user_data
+++ b/tasks/web_user_data
@@ -38,8 +38,8 @@ END
 sudo -u ubuntu bash <<'END'
 export NVM_DIR=$HOME/.nvm
 source $NVM_DIR/nvm.sh
-nvm install 4.4.7
-nvm alias default 4.4.7
+nvm install lts/boron
+nvm alias default lts/boron
 npm install --production
 ./node_modules/.bin/wintersmith build --config=config/blog.js
 END


### PR DESCRIPTION
This unpins us from the out-of-date v4.4.7 and instead installs the latest version from the "Boron" LTS release line. With this, we'll only have to spin up new instances to pick up security fixes, plus update the LTS release line again every year. (or three)

I haven't deployed this yet, but I did test the commands in a container, and the site's test suite runs fine on v6.9.1. (FWIW Travis CI has been testing on v6 for some time now)