### PR TITLE
Add featured report (EPA Flint, MI)

### DIFF
--- a/config/featured.yaml
+++ b/config/featured.yaml
@@ -23,3 +23,12 @@ doj:
     to end use of privately operated prisons."
     author: David Cook
     author_link: "https://twitter.com/divergentdave"
+epa:
+  17-P-0004:
+    description: "The EPA's OIG found that EPA Region 5 should have intervened
+    sooner in the Flint, MI water crisis. Since Michigan's actions failed to
+    protect the public, the Safe Drinking Water Act gave the EPA the authority
+    to issue an emergency order, though they didn't do so until seven months
+    later."
+    author: David Cook
+    author_link: "https://twitter.com/divergentdave"


### PR DESCRIPTION
"The EPA's OIG found that EPA Region 5 should have intervened sooner in the Flint, MI water crisis. Since Michigan's actions failed to protect the public, the Safe Drinking Water Act gave the EPA the authority to issue an emergency order, though they didn't do so until seven months later."