### PR TITLE
http in npm-shrinkwrap.json

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1891,7 +1891,7 @@
             "are-we-there-yet": {
               "version": "1.1.2",
               "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-              "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
@@ -1950,7 +1950,7 @@
                         "number-is-nan": {
                           "version": "1.0.0",
                           "from": "number-is-nan@^1.0.0",
-                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                         }
                       }
                     }

--- a/tasks/pre-commit
+++ b/tasks/pre-commit
@@ -24,6 +24,10 @@ else # Running locally
     git diff-index --check --cached $against
 fi
 
+if grep --quiet http: npm-shrinkwrap.json; then
+  echo "Error: insecure HTTP URL found in npm-shrinkwrap.json"
+  exit 1
+fi
 ruby -c Gemfile >/dev/null
 ruby -c config/environment.rb >/dev/null
 ruby -c tasks/elasticsearch.rake >/dev/null


### PR DESCRIPTION
See http://blog.npmjs.org/post/154400916805/avoid-http-urls-in-shrinkwrap-files. This fixes the problem and adds a pre-commit/CI check for regressions.