### PR TITLE
Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - elasticsearch
 before_install:
   - npm config set spin false
-  - rvm install 2.3.3
+  - rvm install 2.4.0
 install:
   - npm install
   - bundle install --jobs=3 --retry=3 --deployment

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'elasticsearch-persistence'
-gem 'activemodel', '~> 4.0'
+gem 'elasticsearch'
 gem 'big_sitemap'
 
 gem 'listen', '~> 2.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'elasticsearch'
+gem 'elasticsearch', '~> 2'
 gem 'big_sitemap'
 
 gem 'listen', '~> 2.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,73 +3,38 @@ GEM
   specs:
     acme-client (0.4.1)
       faraday (~> 0.9, >= 0.9.1)
-    activemodel (4.2.7.1)
-      activesupport (= 4.2.7.1)
-      builder (~> 3.1)
-    activesupport (4.2.7.1)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
     aws-sdk (2.6.18)
       aws-sdk-resources (= 2.6.18)
     aws-sdk-core (2.6.18)
       jmespath (~> 1.0)
     aws-sdk-resources (2.6.18)
       aws-sdk-core (= 2.6.18)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     big_sitemap (1.1.0)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
-    builder (3.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     elasticsearch (2.0.0)
       elasticsearch-api (= 2.0.0)
       elasticsearch-transport (= 2.0.0)
     elasticsearch-api (2.0.0)
       multi_json
-    elasticsearch-model (0.1.9)
-      activesupport (> 3)
-      elasticsearch (> 0.4)
-      hashie
-    elasticsearch-persistence (0.1.9)
-      activemodel (> 3)
-      activesupport (> 3)
-      elasticsearch (> 0.4)
-      elasticsearch-model (>= 0.1)
-      hashie
-      virtus
     elasticsearch-transport (2.0.0)
       faraday
       multi_json
-    equalizer (0.0.11)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware-aws-signers-v4 (0.1.5)
       aws-sdk (~> 2.1)
       faraday (~> 0.9)
     ffi (1.9.14)
-    hashie (3.4.6)
     hitimes (1.2.4)
-    i18n (0.7.0)
-    ice_nine (0.11.2)
     jmespath (1.3.1)
-    json (1.8.3)
     listen (2.10.1)
       celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    minitest (5.9.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     neat (1.8.0)
@@ -80,27 +45,18 @@ GEM
       ffi (>= 0.5.0)
     sass (3.4.22)
     thor (0.19.1)
-    thread_safe (0.3.5)
     timers (4.0.4)
       hitimes
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   acme-client
-  activemodel (~> 4.0)
   aws-sdk (>= 2.5.7)
   big_sitemap
   bourbon
-  elasticsearch-persistence
+  elasticsearch
   faraday_middleware-aws-signers-v4
   listen (~> 2.8)
   neat

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    acme-client (0.4.1)
+    acme-client (0.5.0)
       faraday (~> 0.9, >= 0.9.1)
-    aws-sdk (2.6.18)
-      aws-sdk-resources (= 2.6.18)
-    aws-sdk-core (2.6.18)
+    aws-sdk (2.6.44)
+      aws-sdk-resources (= 2.6.44)
+    aws-sdk-core (2.6.44)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.18)
-      aws-sdk-core (= 2.6.18)
+    aws-sdk-resources (2.6.44)
+      aws-sdk-core (= 2.6.44)
+    aws-sigv4 (1.0.0)
     big_sitemap (1.1.0)
     bourbon (4.2.7)
       sass (~> 3.4)
@@ -23,7 +25,7 @@ GEM
     elasticsearch-transport (2.0.0)
       faraday
       multi_json
-    faraday (0.9.2)
+    faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware-aws-signers-v4 (0.1.5)
       aws-sdk (~> 2.1)
@@ -43,8 +45,8 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    sass (3.4.22)
-    thor (0.19.1)
+    sass (3.4.23)
+    thor (0.19.4)
     timers (4.0.4)
       hitimes
 
@@ -56,11 +58,11 @@ DEPENDENCIES
   aws-sdk (>= 2.5.7)
   big_sitemap
   bourbon
-  elasticsearch
+  elasticsearch (~> 2)
   faraday_middleware-aws-signers-v4
   listen (~> 2.8)
   neat
   sass
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,7 +3,7 @@
 
 require 'bundler/setup'
 require 'aws-sdk'
-require 'elasticsearch/persistence/model'
+require 'elasticsearch'
 require 'faraday_middleware/aws_signers_v4'
 require 'yaml'
 
@@ -52,23 +52,3 @@ class Environment
 end
 
 Environment.init_client!
-
-
-## Models for easy introspection.
-
-class Report
-  include Elasticsearch::Persistence::Model
-  index_name Environment.config['elasticsearch']['index_read']
-  document_type "reports"
-
-  attribute :title, String
-  attribute :inspector, String
-  attribute :agency, String
-  attribute :featured, Hash
-  attribute :is_featured, Boolean
-  attribute :report_id, String
-  attribute :pdf, Hash
-  attribute :type, String
-  attribute :url, String
-  attribute :year, Fixnum
-end

--- a/tasks/letsencrypt/letsencrypt.rake
+++ b/tasks/letsencrypt/letsencrypt.rake
@@ -1,6 +1,3 @@
-require 'active_support'
-require 'active_support/core_ext'
-
 require_relative 'lets_encrypt_route53'
 
 namespace :letsencrypt do
@@ -36,8 +33,8 @@ namespace :letsencrypt do
        '30 days'
   task :renew do
     expires_in = le.expires_in
-    if !expires_in.nil? && expires_in > 30.days
-      days = expires_in.to_i / 1.day
+    if !expires_in.nil? && expires_in > 30 * 24 * 60 * 60
+      days = expires_in.to_i / 24 / 60 / 60
       puts "Current certificate is valid, and expires in #{days} days. "\
            'Not updating.'
     else

--- a/tasks/letsencrypt/letsencrypt_scrapers.rake
+++ b/tasks/letsencrypt/letsencrypt_scrapers.rake
@@ -30,8 +30,8 @@ namespace :letsencrypt_scrapers do
        '30 days'
   task :renew do
     expires_in = le.expires_in
-    if !expires_in.nil? && expires_in > 30.days
-      days = expires_in.to_i / 1.day
+    if !expires_in.nil? && expires_in > 30 * 24 * 60 * 60
+      days = expires_in.to_i / 24 / 60 / 60
       puts "Current certificate is valid, and expires in #{days} days. "\
            'Not updating.'
     else

--- a/tasks/scraper_user_data
+++ b/tasks/scraper_user_data
@@ -62,8 +62,8 @@ cd oversight.garden
 
 sudo -u ubuntu bash <<'END'
 source $HOME/.rvm/scripts/rvm
-rvm install 2.3.3
-rvm use 2.3.3 --default
+rvm install 2.4.0
+rvm use 2.4.0 --default
 gem install bundler
 bundle install
 rake letsencrypt_scrapers:fetch

--- a/tasks/web_user_data
+++ b/tasks/web_user_data
@@ -28,8 +28,8 @@ sudo -u ubuntu git clone https://github.com/konklone/oversight.garden.git .
 
 sudo -u ubuntu bash <<'END'
 source $HOME/.rvm/scripts/rvm
-rvm install 2.3.3
-rvm use 2.3.3 --default
+rvm install 2.4.0
+rvm use 2.4.0 --default
 gem install bundler
 bundle install
 rake letsencrypt:fetch


### PR DESCRIPTION
This cleans out the last couple uses of activerecord/activesupport and upgrades to Ruby 2.4.0. See also #170.