### PR TITLE
<link> to the first page of ATOM feeds

### DIFF
--- a/views/layout/header.html
+++ b/views/layout/header.html
@@ -54,8 +54,8 @@
   <link rel="canonical" href="https://oversight.garden/blog<%= page.url %>" />
 <% } %>
 
-<% if (req && req.originalUrl.startsWith("/reports")) { -%>
-  <link rel="alternate" type="application/atom+xml" title="Search Results" href="<%= req.originalUrl.replace("/reports", "/reports.xml") %>" />
+<% if (typeof(query_obj) != "undefined") { -%>
+  <link rel="alternate" type="application/atom+xml" title="Search Results" href="/reports.xml?<%= helpers.format_qs(query_obj, {page: 1}) %>" />
 <% } -%>
 
 <meta name="twitter:card" content="summary" />


### PR DESCRIPTION
Inspired by #185. Since the number of reports per page is different between HTML and ATOM pages, it doesn't make sense for page 400 of the HTML ​search results to link to page 400 of the ATOM feed.

This still needs some testing