### PR TITLE
Fix single report URL

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -159,6 +159,13 @@ module.exports = function(app) {
     });
   });
 
+  app.get('/report/:inspector/:report_id', function(req, res) {
+    res.redirect(301, "/reports/" +
+                      encodeURIComponent(req.params.inspector) +
+                      "/" +
+                      encodeURIComponent(req.params.report_id));
+  });
+
   app.get('/dashboard', function(req, res) {
     es.search({
       index: config.elasticsearch.index_dashboard,

--- a/tasks/sitemap.rake
+++ b/tasks/sitemap.rake
@@ -50,7 +50,7 @@ namespace :sitemap do
             next if report_id == "." or report_id == ".."
             next if not File.directory?(File.join(data_dir, inspector, year, report_id))
             next if not File.exist?(File.join(data_dir, inspector, year, report_id, "report.json"))
-            add "/report/" + inspector + "/" + CGI.escape(report_id), change_frequency: "monthly"
+            add "/reports/" + inspector + "/" + CGI.escape(report_id), change_frequency: "monthly"
           end
         end
       end


### PR DESCRIPTION
Whoops, it turns out every URL in our sitemap has been returning a 404 error ever since we switched from `/report/...` to `/reports/...`. This fixes the issue by adding a route at the old address for "301 Moved Permanently" redirects and fixing the path in the sitemap.

Closes #215