### PR TITLE
Don't index sitemap listings themselves

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,11 @@ app.enable('trust proxy')
   });
 
 if (config && config.sitemap && config.sitemap.directory) {
-  app.use('/sitemap', express.static(config.sitemap.directory));
+  app.use('/sitemap', express.static(config.sitemap.directory, {
+    setHeaders: function (res, path, stat) {
+      res.set("X-Robots-Tag", "noindex");
+    }
+  }));
 }
 
 app.use(express.static(__dirname + '/public'));


### PR DESCRIPTION
Add the `noindex` HTTP header to the sitemap responses, since we may wish to avoid indexing certain names that also appear in the URLs themselves of the reports.